### PR TITLE
fixing typo in the word decentralized

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -247,7 +247,7 @@
                 <h2 class="anim">Want to learn more?</h2>
             </div>
             <p class="anim blog__subtitle">
-                We are constantly writing about our work to create a more descentralized world. Check out our latest story.
+                We are constantly writing about our work to create a more decentralized world. Check out our latest story.
             </p>
             <div class="anim blog__content flex-d">
                 <div class="blog__content__image tablet">


### PR DESCRIPTION
"decentralized" was spelled incorrectly
"descentralized" -> "decentralized"